### PR TITLE
Issue #3: Prevent the ability to scroll the page when the popup is open (fix)

### DIFF
--- a/src/components/BlurOverlay.tsx
+++ b/src/components/BlurOverlay.tsx
@@ -1,8 +1,19 @@
-const BlurOverlay = (props: { isActive: boolean }) => {
-  return (
-    <div className={`w-screen h-screen fixed top-0 left-0 transition-all duration-300 
-      z-20 ${props.isActive ? "backdrop-blur-sm" : "pointer-events-none"}`} />
-  );
-}
+import { useEffect } from "react";
 
-export default BlurOverlay
+const BlurOverlay = (props: { isActive: boolean }) => {
+    useEffect(() => {
+        if (props.isActive) {
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = "unset";
+        }
+    }, [props.isActive]);
+    return (
+        <div
+            className={`w-screen h-screen fixed top-0 left-0 transition-all duration-300 
+      z-20 ${props.isActive ? "backdrop-blur-sm" : "pointer-events-none"}`}
+        />
+    );
+};
+
+export default BlurOverlay;


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed.
Updated the blur overlay to make body overflow: hidden when isActive is True => i.e. prevent scrolling.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style and structure of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, bugs or errors